### PR TITLE
Add configuration options for report-path and message

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information see [Gitalb test coverage parsing](https://docs.gitlab.com/
 
 ## Getting Started
 
-Add this snippet to yout build script.
+Add this snippet to your build script.
 
 ```
 plugins {
@@ -33,16 +33,32 @@ build-gradle:
 
 ## Configuration
 
+Configuration for the default 'printCoverage' task:
 ```
 printcoverage {
   coverageType = 'INSTRUCTION'
+  reportFile = "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+  message = 'Coverage: %s%%'
 }
 ```
 
 * `coverageType`: Type of [coverage metric](http://www.eclemma.org/jacoco/trunk/doc/counters.html) to be printed.<br>
   One of 'INSTRUCTION', 'BRANCH', 'LINE', 'COMPLEXITY', 'METHOD' or 'CLASS'<br>
   Default: 'INSTRUCTION'
+* `reportFile`: Path to the Jacoco xml-report to be used   
+  Default: "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+* `message`: Format string to be used for printing the coverage information   
+  Default: 'Coverage: %s%%'
 
+To print coverage information for different reports, define custom tasks:
+```
+task printCombinedCoverage(type: PrintCoverage) {
+  reportFile = "$buildDir/reports/jacoco/combinedCoverageReport/combinedCoverageReport.xml"
+  message = 'Total Coverage: %s%%'
+}
+```
+ 
+  
 ## Publishing Workflow
 
 Every commit on this repository gets tested via [circleci](https://circleci.com/gh/jansauer/gradle-print-coverage-plugin).

--- a/src/main/groovy/de/jansauer/printcoverage/PrintCoverageExtension.groovy
+++ b/src/main/groovy/de/jansauer/printcoverage/PrintCoverageExtension.groovy
@@ -6,9 +6,12 @@ import org.gradle.api.provider.Property
 class PrintCoverageExtension {
 
   final Property<String> coverageType
+  final Property<String> reportFile
+  final Property<String> message
 
   PrintCoverageExtension(Project project) {
     coverageType = project.objects.property(String)
-    coverageType.set('INSTRUCTION')
+    reportFile = project.objects.property(String)
+    message = project.objects.property(String)
   }
 }

--- a/src/main/groovy/de/jansauer/printcoverage/PrintCoveragePlugin.groovy
+++ b/src/main/groovy/de/jansauer/printcoverage/PrintCoveragePlugin.groovy
@@ -15,9 +15,15 @@ class PrintCoveragePlugin implements Plugin<Project> {
     }
 
     def extension = target.extensions.create('printcoverage', PrintCoverageExtension, target)
+
     Task task = target.tasks.create('printCoverage', PrintCoverageTask) {
       coverageType = extension.coverageType
+      reportFile = extension.reportFile
+      message = extension.message
     }
+
+    target.ext.PrintCoverage = PrintCoverageTask
+
     task.dependsOn(target.tasks.withType(JacocoReport))
   }
 }


### PR DESCRIPTION
We have multiple sub-projects and want to display a separate message for the combined coverage. This pull-request adds configuration options for 'reportPath' and 'message' to customize both the xml-report from jacoco to be scanned for coverage data as well as the output message.