### PR TITLE
Use Gradle task avoidance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+tab_width = 4
+
+[*.groovy]
+indent_size = 2

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-  testCompile('org.spockframework:spock-core:1.2-groovy-2.5') {
+  testImplementation('org.spockframework:spock-core:1.2-groovy-2.5') {
     exclude(module: 'groovy-all')
   }
 }

--- a/src/main/groovy/de/jansauer/printcoverage/PrintCoveragePlugin.groovy
+++ b/src/main/groovy/de/jansauer/printcoverage/PrintCoveragePlugin.groovy
@@ -2,22 +2,21 @@ package de.jansauer.printcoverage
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.testing.jacoco.tasks.JacocoReport
 
 class PrintCoveragePlugin implements Plugin<Project> {
 
   void apply(Project target) {
-    target.tasks.withType(JacocoReport) {
+    target.tasks.withType(JacocoReport).configureEach() {
       reports {
         xml.enabled true
       }
     }
 
     def extension = target.extensions.create('printcoverage', PrintCoverageExtension, target)
-    Task task = target.tasks.create('printCoverage', PrintCoverageTask) {
-      coverageType = extension.coverageType
+    target.tasks.register('printCoverage', PrintCoverageTask) {
+      it.coverageType.set(extension.coverageType.get())
+      it.dependsOn(target.tasks.withType(JacocoReport))
     }
-    task.dependsOn(target.tasks.withType(JacocoReport))
   }
 }

--- a/src/test/groovy/de/jansauer/printcoverage/PrintCoveragePluginTest.groovy
+++ b/src/test/groovy/de/jansauer/printcoverage/PrintCoveragePluginTest.groovy
@@ -1,6 +1,5 @@
 package de.jansauer.printcoverage
 
-import org.gradle.internal.impldep.org.junit.Rule
 import org.gradle.internal.impldep.org.junit.rules.TemporaryFolder
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
@@ -11,7 +10,7 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
 class PrintCoveragePluginTest extends Specification {
 
-  final static String[] SUPPORTED_GRADLE_VERSIONS = ['4.10', '4.10.1', '4.10.2', '5.0', '4.10.3', '5.1', '5.1.1']
+  final static String[] SUPPORTED_GRADLE_VERSIONS = ['4.10', '4.10.1', '4.10.2', '5.0', '4.10.3', '5.1', '5.1.1', '5.6.4', '6.9.2', '7.5.1']
 
   TemporaryFolder temporaryFolder
 
@@ -100,7 +99,7 @@ class PrintCoveragePluginTest extends Specification {
         }
         
         dependencies {
-          testCompile 'junit:junit:4.12'
+          testImplementation 'junit:junit:4.12'
         }
     """
     File classFile = temporaryFolder


### PR DESCRIPTION
This PR implements task avoidance inside the plugin, because it always configures JaCoCo (and in consequence the `test` task), even if it is not used in the build. To reproduce, create a build scan with `./gradlew --scan help` and check the output as described in the ["Troubleshooting" section in the manual](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_troubleshooting). The current release shows 3 created tasks, the version with this PR applied shows 0.

I also took the liberty too add the most recent major versions to the tests and make minor modifications so that the plugin can be used in a composite build with recent Gradle releases. (I needed that for manual testing and creating the build scans.)

Thanks for this great plugin!