### PR TITLE
support multiple testsets in one gradle project

### DIFF
--- a/src/test/resources/CalculatorIT.java
+++ b/src/test/resources/CalculatorIT.java
@@ -1,0 +1,12 @@
+package sample;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CalculatorIT {
+
+  @Test
+  public void startsCalculator() {
+    Calculator.main(new String[0]);
+  }
+}


### PR DESCRIPTION
We have in many projects unit tests and integration tests in different test sets. 

JaCoCo can handle this out of the box, but printCoverage only prints the coverage of the unit tests. 

So I added a loop over the existing test sets and print each coverage. 
To be backwards-compatible, the single test sets print the name of the test set so that this does not clash with the existing grep for "Coverage: ". 

The resulting Coverage is just the maximum value of the test sets as we are here not able to differ if the coverage is overlapping or not - usually it is. 